### PR TITLE
Removing degree symbol from the intermagnet observatory file 

### DIFF
--- a/bezpy/mag/data/intermagnet_observatories.dat
+++ b/bezpy/mag/data/intermagnet_observatories.dat
@@ -1,151 +1,151 @@
 IAGA	Name	Country	Colatitute	East Longitude	Institute	GIN
-AAA	Alma Ata	Kazakhstan	46.8°	76.9°	IIRK	Edi
-AAE	Addis Ababa	Ethiopia	80.97°	38.77°	AAU, IPGP	Par
-ABG	Alibag	India	71.38°	72.87°	IIG	Kyo
-ABK	Abisko	Sweden	21.642°	18.823°	SGU	Edi
-AIA	Argentine Islands (Akademik Vernadsky base)	Antarctica	155.25°	295.75°	NASC	Ott
-ALE*	Alert	Canada	7.503°	297.647°	GSC	Ott
-AMS	Martin de Vivies-Amsterdam Island	French Southern and Antarctic Lands	127.8°	77.57°	EOST	Par
-API	Apia	Western Samoa	103.8°	188.22°	MNRE	Edi
-AQU*	L'Aquila	Italy	47.62°	13.32°	INGV	Par
-ARS	Arti	Russia	33.567°	58.567°	IG UB RAS, GCRAS	Edi
-ASC	Ascension Island	United Kingdom	97.95°	345.62°	BGS	Edi
-ASP	Alice Springs	Australia	113.77°	133.88°	GA	Edi
-BDV	Budkov	Czech Republic	40.92°	14.02°	ASCR	Edi
-BEL	Belsk	Poland	38.16°	20.79°	PAS	Edi
-BFE*	Brorfelde	Denmark	34.375°	11.672°	DTU	Kyo
-BFO	Black Forest	Germany	41.669°	8.325°	GGUKS	Edi
-BLC	Baker Lake	Canada	25.682°	263.988°	GSC	Ott
-BMT	Beijing Ming Tombs	China	49.7°	116.2°	IGGCAS	Kyo
-BNG*	Bangui	Central African Republic	85.67°	18.57°	IRD	Par
-BOU	Boulder	United States of America	49.86°	254.76°	USGS	Gol
-BOX	Borok	Russia	31.93°	38.23°	GCRAS, IPGP	Par
-BRD	Brandon	Canada	40.13°	260.0261°	GSC	Ott
-BRW	Barrow	United States of America	18.68°	203.38°	USGS	Gol
-BSL	Stennis Space Center	United States of America	59.65°	270.36°	USGS	Gol
-CBB	Cambridge Bay	Canada	20.877°	254.969°	GSC	Ott
-CKI	Cocos-Keeling Islands	Australia	102.1875°	96.8336°	GA	Edi
-CLF	Chambon la Foret	France	41.98°	2.27°	IPGP	Par
-CMO	College	United States of America	25.13°	212.14°	USGS	Gol
-CNB	Canberra	Australia	125.32°	149.36°	GA	Edi
-CNH	Changchun	China	45.92°	124.86°	CEA	Edi
-CSY	Casey Station	Antarctica	156.283°	110.533°	GA	Edi
-CTA	Charters Towers	Australia	110.1°	146.3°	GA	Edi
-CYG	Cheongyang	Republic of Korea	53.63°	126.854°	KMA	Kyo
-CZT	Port Alfred	French Southern and Antarctic Lands	136.43°	51.87°	EOST	Par
-DED	Deadhorse	United States of America	19.64°	211.21°	USGS	Gol
-DLR*	Del Rio	United States of America	60.5°	259.08°	USGS	Gol
-DLT	Dalat	Vietnam	78.06°	108.48°	VAST, IPGP	Par
-DMC	Dome C	Antarctica	165.25°	124.167°	EOST, INGV	Par
-DOU	Dourbes	Belgium	39.9°	4.6°	RMIB	Edi
-DRV	Dumont d'Urville	Antarctica	156.67°	140.01°	EOST	Par
-DUR	Duronia	Italy	48.61°	14.28°	INGV	Par
-EBR	Ebro	Spain	49.043°	0.333°	OEB	Par
-ESK	Eskdalemuir	United Kingdom	34.68°	356.8°	BGS	Edi
-EYR	Eyrewell	New Zealand	133.474°	172.393°	GNS	Edi
-FCC	Fort Churchill	Canada	31.241°	265.912°	GSC	Ott
-FRD	Fredericksburg	United States of America	51.8°	282.63°	USGS	Gol
-FRN	Fresno	United States of America	52.91°	240.28°	USGS	Gol
-FUR	Furstenfeldbruck	Germany	41.83°	11.28°	LMU	Edi
-GAN	Gan	Maldives	89.3054°	73.1537°	ETH	Edi
-GCK	Grocka	Serbia	45.4°	20.8°	GIG	Edi
-GDH	Qeqertarsuaq (Godhavn)	Greenland	20.748°	306.467°	DTU	Kyo
-GLN*	Glenlea	Canada	40.355°	262.880°	GSC	Ott
-GNA*	Gnangara	Australia	121.8°	116.0°	GA	Edi
-GNG	Gingin	Australia	121.356°	115.715°	GA	Edi
-GUA	Guam	United States of America	76.41°	144.87°	USGS	Gol
-GUI	Guimar-Tenerife	Spain	61.68°	343.57°	IGNS	Par
-GZH	Zhaoqing	China	67°	112.5°	CEA	Edi
-HAD	Hartland	United Kingdom	39°	355.52°	BGS	Edi
-HBK	Hartebeesthoek	South Africa	115.88°	27.71°	SANSA	Edi
-HER	Hermanus	South Africa	124.43°	19.23°	SANSA	Edi
-HLP	Hel	Poland	35.39°	18.82°	PAS	Edi
-HON	Honolulu	United States of America	68.68°	202.0°	USGS	Gol
-HRB	Hurbanovo	Slovakia	42.14°	18.19°	SAS	Par
-HRN	Hornsund	Norway	13°	15.37°	PAS	Edi
-HUA	Huancayo	Peru	102.05°	284.67°	IGP	Edi
-HYB	Hyderabad	India	72.6°	78.6°	NGRI, GFZ	Edi
-IPM	Isla de Pascua Mataveri (Easter Island)	Chile	117.2°	250.58°	DMC, IPGP	Par
-IQA	Iqaluit	Canada	26.247°	291.482°	GSC	Ott
-IRT	Irkutsk	Russia	37.73°	104.45°	ISTP SB RAS	Edi
-ISK*	Kandilli	Turkey	48.9°	29.1°	KEORI	Edi
-IZN	Iznik	Turkey	49.5°	29.72°	KEORI	Edi
-JAI	Jaipur	India	63.08°	75.80°	IIG	Kyo
-JCO	Jim Carrigan Observatory	United States of America	19.644°	211.201°	HAL, BGS	Edi
-KAK	Kakioka	Japan	53.77°	140.18°	JMA	Kyo
-KDU	Kakadu	Australia	102.69°	132.47°	GA	Edi
-KEP	King Edward Point	South Georgia and the South Sandwich Islands	144.2821°	323.5071°	BGS	Edi
-KHB	Khabarovsk	Russia	42.39°	134.69°	IKIR	Edi
-KIV	Kiev	Ukraine	39.28°	30.3°	NASU	Edi
-KMH	Keetmanshoop	Namibia	116.54°	18.110°	SANSA, GFZ	Edi
-KNY	Kanoya	Japan	58.58°	130.88°	JMA	Kyo
-KOU	Kourou	French Guiana	84.79°	307.27°	IPGP	Par
-LER	Lerwick	United Kingdom	29.87°	358.82°	BGS	Edi
-LNP*	Lunping	Taiwan	65°	121.2°	DGT	Kyo
-LON	Lonjsko Polje	Croatia	44.5919°	16.6592°	UNIZG	Edi
-LOV*	Lovoe	Sweden	30.66°	17.82°	SGU	Edi
-LRM	Learmonth	Australia	112.22°	114.1°	GA	Edi
-LVV	Lviv	Ukraine	40.1°	23.75°	NASU	Edi
-LYC	Lycksele	Sweden	25.4°	18.8°	SGU	Edi
-LZH	Lanzhou	China	53.9°	103.84°	CEA, IPGP	Par
-MAB	Manhay	Belgium	39.702°	5.682°	RMIB	Edi
-MAW	Mawson	Antarctica	157.6°	62.88°	GA	Edi
-MBC*	Mould Bay	Canada	13.685°	240.638°	GSC	Ott
-MBO	Mbour	Senegal	75.62°	343.03°	IPGP, IRD	Par
-MCQ	Macquarie Island	Australia	144.5°	158.95°	GA	Edi
-MEA	Meanook	Canada	35.384°	246.653°	GSC	Ott
-MGD	Magadan	Russia	29.949°	150.728°	IKIR	Edi
-MID*	Midway Island	United States of America	61.79°	182.62°	USGS	Gol
-MMB	Memambetsu	Japan	46.09°	144.19°	JMA	Kyo
-NAQ	Narsarsuaq	Greenland	28.84°	314.558°	DTU	Kyo
-NCK	Nagycenk	Hungary	42.37°	16.72°	HAS	Edi
-NEW	Newport	United States of America	41.73°	242.88°	USGS	Gol
-NGK	Niemegk	Germany	37.93°	12.68°	GFZ	Edi
-NUR	Nurmijarvi	Finland	29.49°	24.66°	FMI	Edi
-NVS	Novosibirsk	Russia	35.15°	83.23°	ASB GS SB RAS	Edi
-ORC	Orcadas	Argentina	150.737°	315.26°	SMN	Edi
-OTT	Ottawa	Canada	44.597°	284.448°	GSC	Ott
-PAF	Port-aux-Francais	French Southern and Antarctic Lands	139.35°	70.26°	EOST	Par
-PAG	Panagjurishte	Bulgaria	47.5°	24.2°	NIGGG-BAS, GFZ	Edi
-PBQ*	Poste-de-la-Baleine	Canada	34.723°	282.255°	GSC	Ott
-PEG	Pedeli	Greece	51.9°	23.9°	IGME	Edi
-PET	Paratunka	Russia	37.029°	158.248°	IKIR	Edi
-PHU	Phuthuy	Vietnam	68.97°	105.95°	VAST, IPGP	Par
-PIL	Pilar	Argentina	121.4°	296.12°	SMN	Edi
-PPT	Pamatai	French Polynesia	107.57°	210.42°	IPGP	Par
-PST	Port Stanley	Falkland Islands	141.7°	302.11°	BGS	Edi
-QSB*	Qsaybeh	Lebanon	56.1°	35.6°	NCGR, IPGP	Par
-RES	Resolute Bay	Canada	15.31°	265.105°	GSC	Ott
-SBA	Scott Base	Antarctica	167.85°	166.78°	GNS	Edi
-SBL	Sable Island	Canada	46.0679°	299.9905°	BGS	Edi
-SFS	San Fernando	Spain	53.333°	354.055°	RIOA	Par
-SHU	Shumagin	United States of America	34.65°	199.54°	USGS	Gol
-SIT	Sitka	United States of America	32.94°	224.67°	USGS	Gol
-SJG	San Juan	United States of America	71.89°	293.85°	USGS	Gol
-SOD	Sodankyla	Finland	22.63°	26.63°	SOD	Edi
-SON	Sonmiani	Pakistan	64.8832°	66.4487°	SUPARCO	Edi
-SPG	Saint Petersburg	Russia	29.458°	29.716°	GCRAS	Par
-SPT	San Pablo-Toledo	Spain	50.45°	355.65°	IGNS	Par
-STJ	St John's	Canada	42.405°	307.323°	GSC	Ott
-SUA	Surlari	Romania	45.32°	26.25°	GIR, GFZ	Par
-TAM	Tamanrasset	Algeria	67.21°	5.53°	CRAAG, IPGP	Par
-TAN*	Antananarivo	Madagascar	108.917°	47.552°	IOGA, EOST	Par
-TDC	Tristan da Cunha	Tristan da Cunha	127.067°	347.685°	GFZ, DTU	Kyo
-TEO*	Teoloyucan	Mexico	70.25°	260.81°	IG/UNAM	Edi
-THL	Qaanaaq (Thule)	Greenland	12.53°	290.773°	DTU	Kyo
-THY	Tihany	Hungary	43.1°	17.89°	MFGI	Edi
-TIK*	Tixie Bay	Russia	18.4°	129.0°	IZMIRAN	NA
-TRW	Trelew	Argentina	133.3°	294.7°	UNLP, RMIB	Edi
-TSU	Tsumeb	Namibia	109.202°	17.584°	SANSA	Edi
-TUC	Tucson	United States of America	57.82°	249.27°	USGS	Gol
-UPS	Uppsala	Sweden	30.097°	17.353°	SGU	Edi
-VAL	Valentia	Ireland	38.067°	349.75°	IMS	Edi
-VIC	Victoria	Canada	41.48°	236.580°	GSC	Ott
-VNA	Neumayer Station Ⅲ	Antarctica	160.683°	-8.283°	AWI, GFZ	Kyo
-VOS	Vostok	Antarctica	168.464°	106.835°	AARI	Kyo
-VSS	Vassouras	Brazil	112.4°	316.35°	ON, GFZ	Par
-WIC	Conrad Observatory	Austria	42.0695°	15.8657°	ZAMG	Edi
-WMQ	Urumqi	China	46.19°	87.71°	CEA	Edi
-WNG	Wingst	Germany	36.26°	9.07°	GFZ	Edi
-YAK	Yakutsk	Russia	28.04°	129.66°	IKFIA, GFZ	Edi
-YKC	Yellowknife	Canada	27.52°	245.518°	GSC	Ott
+AAA	Alma Ata	Kazakhstan	46.8	76.9	IIRK	Edi
+AAE	Addis Ababa	Ethiopia	80.97 	38.77 	AAU, IPGP	Par
+ABG	Alibag	India	71.38	72.87	IIG	Kyo
+ABK	Abisko	Sweden	21.642	18.823	SGU	Edi
+AIA	Argentine Islands (Akademik Vernadsky base)	Antarctica	155.25	295.75	NASC	Ott
+ALE*	Alert	Canada	7.503	297.647	GSC	Ott
+AMS	Martin de Vivies-Amsterdam Island	French Southern and Antarctic Lands	127.8	77.57	EOST	Par
+API	Apia	Western Samoa	103.8	188.22	MNRE	Edi
+AQU*	L'Aquila	Italy	47.62	13.32	INGV	Par
+ARS	Arti	Russia	33.567	58.567	IG UB RAS, GCRAS	Edi
+ASC	Ascension Island	United Kingdom	97.95	345.62	BGS	Edi
+ASP	Alice Springs	Australia	113.77	133.88	GA	Edi
+BDV	Budkov	Czech Republic	40.92	14.02	ASCR	Edi
+BEL	Belsk	Poland	38.16	20.79	PAS	Edi
+BFE*	Brorfelde	Denmark	34.375	11.672	DTU	Kyo
+BFO	Black Forest	Germany	41.669	8.325	GGUKS	Edi
+BLC	Baker Lake	Canada	25.682	263.988	GSC	Ott
+BMT	Beijing Ming Tombs	China	49.7	116.2	IGGCAS	Kyo
+BNG*	Bangui	Central African Republic	85.67	18.57	IRD	Par
+BOU	Boulder	United States of America	49.86	254.76	USGS	Gol
+BOX	Borok	Russia	31.93	38.23	GCRAS, IPGP	Par
+BRD	Brandon	Canada	40.13	260.0261	GSC	Ott
+BRW	Barrow	United States of America	18.68	203.38	USGS	Gol
+BSL	Stennis Space Center	United States of America	59.65	270.36	USGS	Gol
+CBB	Cambridge Bay	Canada	20.877	254.969	GSC	Ott
+CKI	Cocos-Keeling Islands	Australia	102.1875	96.8336	GA	Edi
+CLF	Chambon la Foret	France	41.98	2.27	IPGP	Par
+CMO	College	United States of America	25.13	212.14	USGS	Gol
+CNB	Canberra	Australia	125.32	149.36	GA	Edi
+CNH	Changchun	China	45.92	124.86	CEA	Edi
+CSY	Casey Station	Antarctica	156.283	110.533	GA	Edi
+CTA	Charters Towers	Australia	110.1	146.3	GA	Edi
+CYG	Cheongyang	Republic of Korea	53.63	126.854	KMA	Kyo
+CZT	Port Alfred	French Southern and Antarctic Lands	136.43	51.87	EOST	Par
+DED	Deadhorse	United States of America	19.64	211.21	USGS	Gol
+DLR*	Del Rio	United States of America	60.5	259.08	USGS	Gol
+DLT	Dalat	Vietnam	78.06	108.48	VAST, IPGP	Par
+DMC	Dome C	Antarctica	165.25	124.167	EOST, INGV	Par
+DOU	Dourbes	Belgium	39.9	4.6	RMIB	Edi
+DRV	Dumont d'Urville	Antarctica	156.67	140.01	EOST	Par
+DUR	Duronia	Italy	48.61	14.28	INGV	Par
+EBR	Ebro	Spain	49.043	0.333	OEB	Par
+ESK	Eskdalemuir	United Kingdom	34.68	356.8	BGS	Edi
+EYR	Eyrewell	New Zealand	133.474	172.393	GNS	Edi
+FCC	Fort Churchill	Canada	31.241	265.912	GSC	Ott
+FRD	Fredericksburg	United States of America	51.8	282.63	USGS	Gol
+FRN	Fresno	United States of America	52.91	240.28	USGS	Gol
+FUR	Furstenfeldbruck	Germany	41.83	11.28	LMU	Edi
+GAN	Gan	Maldives	89.3054	73.1537	ETH	Edi
+GCK	Grocka	Serbia	45.4	20.8	GIG	Edi
+GDH	Qeqertarsuaq (Godhavn)	Greenland	20.748	306.467	DTU	Kyo
+GLN*	Glenlea	Canada	40.355	262.880	GSC	Ott
+GNA*	Gnangara	Australia	121.8	116.0	GA	Edi
+GNG	Gingin	Australia	121.356	115.715	GA	Edi
+GUA	Guam	United States of America	76.41	144.87	USGS	Gol
+GUI	Guimar-Tenerife	Spain	61.68	343.57	IGNS	Par
+GZH	Zhaoqing	China	67	112.5	CEA	Edi
+HAD	Hartland	United Kingdom	39	355.52	BGS	Edi
+HBK	Hartebeesthoek	South Africa	115.88	27.71	SANSA	Edi
+HER	Hermanus	South Africa	124.43	19.23	SANSA	Edi
+HLP	Hel	Poland	35.39	18.82	PAS	Edi
+HON	Honolulu	United States of America	68.68	202.0	USGS	Gol
+HRB	Hurbanovo	Slovakia	42.14	18.19	SAS	Par
+HRN	Hornsund	Norway	13	15.37	PAS	Edi
+HUA	Huancayo	Peru	102.05	284.67	IGP	Edi
+HYB	Hyderabad	India	72.6	78.6	NGRI, GFZ	Edi
+IPM	Isla de Pascua Mataveri (Easter Island)	Chile	117.2	250.58	DMC, IPGP	Par
+IQA	Iqaluit	Canada	26.247	291.482	GSC	Ott
+IRT	Irkutsk	Russia	37.73	104.45	ISTP SB RAS	Edi
+ISK*	Kandilli	Turkey	48.9	29.1	KEORI	Edi
+IZN	Iznik	Turkey	49.5	29.72	KEORI	Edi
+JAI	Jaipur	India	63.08	75.80	IIG	Kyo
+JCO	Jim Carrigan Observatory	United States of America	19.644	211.201	HAL, BGS	Edi
+KAK	Kakioka	Japan	53.77	140.18	JMA	Kyo
+KDU	Kakadu	Australia	102.69	132.47	GA	Edi
+KEP	King Edward Point	South Georgia and the South Sandwich Islands	144.2821	323.5071	BGS	Edi
+KHB	Khabarovsk	Russia	42.39	134.69	IKIR	Edi
+KIV	Kiev	Ukraine	39.28	30.3	NASU	Edi
+KMH	Keetmanshoop	Namibia	116.54	18.110	SANSA, GFZ	Edi
+KNY	Kanoya	Japan	58.58	130.88	JMA	Kyo
+KOU	Kourou	French Guiana	84.79	307.27	IPGP	Par
+LER	Lerwick	United Kingdom	29.87	358.82	BGS	Edi
+LNP*	Lunping	Taiwan	65	121.2	DGT	Kyo
+LON	Lonjsko Polje	Croatia	44.5919	16.6592	UNIZG	Edi
+LOV*	Lovoe	Sweden	30.66	17.82	SGU	Edi
+LRM	Learmonth	Australia	112.22	114.1	GA	Edi
+LVV	Lviv	Ukraine	40.1	23.75	NASU	Edi
+LYC	Lycksele	Sweden	25.4	18.8	SGU	Edi
+LZH	Lanzhou	China	53.9	103.84	CEA, IPGP	Par
+MAB	Manhay	Belgium	39.702	5.682	RMIB	Edi
+MAW	Mawson	Antarctica	157.6	62.88	GA	Edi
+MBC*	Mould Bay	Canada	13.685	240.638	GSC	Ott
+MBO	Mbour	Senegal	75.62	343.03	IPGP, IRD	Par
+MCQ	Macquarie Island	Australia	144.5	158.95	GA	Edi
+MEA	Meanook	Canada	35.384	246.653	GSC	Ott
+MGD	Magadan	Russia	29.949	150.728	IKIR	Edi
+MID*	Midway Island	United States of America	61.79	182.62	USGS	Gol
+MMB	Memambetsu	Japan	46.09	144.19	JMA	Kyo
+NAQ	Narsarsuaq	Greenland	28.84	314.558	DTU	Kyo
+NCK	Nagycenk	Hungary	42.37	16.72	HAS	Edi
+NEW	Newport	United States of America	41.73	242.88	USGS	Gol
+NGK	Niemegk	Germany	37.93	12.68	GFZ	Edi
+NUR	Nurmijarvi	Finland	29.49	24.66	FMI	Edi
+NVS	Novosibirsk	Russia	35.15	83.23	ASB GS SB RAS	Edi
+ORC	Orcadas	Argentina	150.737	315.26	SMN	Edi
+OTT	Ottawa	Canada	44.597	284.448	GSC	Ott
+PAF	Port-aux-Francais	French Southern and Antarctic Lands	139.35	70.26	EOST	Par
+PAG	Panagjurishte	Bulgaria	47.5	24.2	NIGGG-BAS, GFZ	Edi
+PBQ*	Poste-de-la-Baleine	Canada	34.723	282.255	GSC	Ott
+PEG	Pedeli	Greece	51.9	23.9	IGME	Edi
+PET	Paratunka	Russia	37.029	158.248	IKIR	Edi
+PHU	Phuthuy	Vietnam	68.97	105.95	VAST, IPGP	Par
+PIL	Pilar	Argentina	121.4	296.12	SMN	Edi
+PPT	Pamatai	French Polynesia	107.57	210.42	IPGP	Par
+PST	Port Stanley	Falkland Islands	141.7	302.11	BGS	Edi
+QSB*	Qsaybeh	Lebanon	56.1	35.6	NCGR, IPGP	Par
+RES	Resolute Bay	Canada	15.31	265.105	GSC	Ott
+SBA	Scott Base	Antarctica	167.85	166.78	GNS	Edi
+SBL	Sable Island	Canada	46.0679	299.9905	BGS	Edi
+SFS	San Fernando	Spain	53.333	354.055	RIOA	Par
+SHU	Shumagin	United States of America	34.65	199.54	USGS	Gol
+SIT	Sitka	United States of America	32.94	224.67	USGS	Gol
+SJG	San Juan	United States of America	71.89	293.85	USGS	Gol
+SOD	Sodankyla	Finland	22.63	26.63	SOD	Edi
+SON	Sonmiani	Pakistan	64.8832	66.4487	SUPARCO	Edi
+SPG	Saint Petersburg	Russia	29.458	29.716	GCRAS	Par
+SPT	San Pablo-Toledo	Spain	50.45	355.65	IGNS	Par
+STJ	St John's	Canada	42.405	307.323	GSC	Ott
+SUA	Surlari	Romania	45.32	26.25	GIR, GFZ	Par
+TAM	Tamanrasset	Algeria	67.21	5.53	CRAAG, IPGP	Par
+TAN*	Antananarivo	Madagascar	108.917	47.552	IOGA, EOST	Par
+TDC	Tristan da Cunha	Tristan da Cunha	127.067	347.685	GFZ, DTU	Kyo
+TEO*	Teoloyucan	Mexico	70.25	260.81	IG/UNAM	Edi
+THL	Qaanaaq (Thule)	Greenland	12.53	290.773	DTU	Kyo
+THY	Tihany	Hungary	43.1	17.89	MFGI	Edi
+TIK*	Tixie Bay	Russia	18.4	129.0	IZMIRAN	NA
+TRW	Trelew	Argentina	133.3	294.7	UNLP, RMIB	Edi
+TSU	Tsumeb	Namibia	109.202	17.584	SANSA	Edi
+TUC	Tucson	United States of America	57.82	249.27	USGS	Gol
+UPS	Uppsala	Sweden	30.097	17.353	SGU	Edi
+VAL	Valentia	Ireland	38.067	349.75	IMS	Edi
+VIC	Victoria	Canada	41.48	236.580	GSC	Ott
+VNA	Neumayer Station Ⅲ	Antarctica	160.683	-8.283	AWI, GFZ	Kyo
+VOS	Vostok	Antarctica	168.464	106.835	AARI	Kyo
+VSS	Vassouras	Brazil	112.4	316.35	ON, GFZ	Par
+WIC	Conrad Observatory	Austria	42.0695	15.8657	ZAMG	Edi
+WMQ	Urumqi	China	46.19	87.71	CEA	Edi
+WNG	Wingst	Germany	36.26	9.07	GFZ	Edi
+YAK	Yakutsk	Russia	28.04	129.66	IKFIA, GFZ	Edi
+YKC	Yellowknife	Canada	27.52	245.518	GSC	Ott


### PR DESCRIPTION
Was notified of an error when importing bezpy on a Windows machine that it wasn't able to parse the intermagnet_observatories.dat file. It looks like there are degree symbols that are causing the issue. I have removed all degree symbols in vim from the file:
```vim
:%s/°//g
```