### PR TITLE
ENH: Add ability to download sites based on network codes

### DIFF
--- a/bezpy/mt/datalogger.py
+++ b/bezpy/mt/datalogger.py
@@ -23,7 +23,7 @@ class DataLogger:
         self.zpk = None
         self.timedelays = None
 
-    def download_iris_waveforms(self, name, start_time, end_time):
+    def download_iris_waveforms(self, name, start_time, end_time, network_code="EM"):
         """Download waveforms from the IRIS client."""
         # The only reason we are putting a global in here is because
         # of how long it takes to create the Client, and with multiple
@@ -40,7 +40,7 @@ class DataLogger:
         # The channels are
         # E: LQN/LQE
         # B: LFN/LFE/LFZ
-        stream = _IRIS_CLIENT.get_waveforms("EM", name, "*", "*",
+        stream = _IRIS_CLIENT.get_waveforms(network_code, name, "*", "*",
                                             UTCDateTime(start_time),
                                             UTCDateTime(end_time))
         # Convert the stream to a pandas DataFrame

--- a/bezpy/mt/io.py
+++ b/bezpy/mt/io.py
@@ -99,7 +99,10 @@ def read_xml(fname):
     # Store the parsed root xml element
     site.xml = root
     site.product_id = get_text(root, "ProductId")
-
+    # Metadata url contains the network code
+    metadata_url = get_text(root.find("ExternalUrl"), "Url")
+    # http://www.iris.edu/mda/EM/VAQ58 -> EM
+    site.network_code = metadata_url.split("/")[-2]
     loc = xml_site.find("Location")
     site.latitude = convert_float(get_text(loc, "Latitude"))
     site.longitude = convert_float(get_text(loc, "Longitude"))

--- a/bezpy/mt/site.py
+++ b/bezpy/mt/site.py
@@ -228,7 +228,8 @@ class Site3d(Site):
 
         self.waveforms = self.datalogger.download_iris_waveforms(self.name,
                                                                  self.start_time,
-                                                                 self.end_time)
+                                                                 self.end_time,
+                                                                 network_code=self.network_code)
 
     def load_waveforms(self, directory="./"):
         """Load the waveform data that has already been downloaded."""


### PR DESCRIPTION
The network code was assumed to be EM for the initial survey sites. Now that there are multiple surveys in the IRIS database, we need to explicitly use the right network code when we go and download the raw data.