### PR TITLE
Add site_rotation to add geographic ability to waveforms

### DIFF
--- a/bezpy/mt/io.py
+++ b/bezpy/mt/io.py
@@ -109,6 +109,17 @@ def read_xml(fname):
     site.elevation = convert_float(get_text(loc, "Elevation"))
     site.declination = convert_float(get_text(loc, "Declination"))
 
+    # Orientation of the channels to geographic north (angle in degrees)
+    site.channel_orientation = {}
+    channel_mapping = {"Hx": "Bx", "Hy": "By", "Hz": "Bz", "Ex": "Ex", "Ey": "Ey"}
+    site_layout = root.find("SiteLayout")
+    for input_output in site_layout:
+        # InputChannels or OutputChannels subelements
+        for channel in input_output:
+            # Individual channels within the subelement
+            channel_name_mapped = channel_mapping[channel.attrib["name"]]
+            site.channel_orientation[channel_name_mapped] = convert_float(channel.attrib["orientation"])
+
     site.start_time = convert_datetime(get_text(xml_site, "Start"))
     site.end_time = convert_datetime(get_text(xml_site, "End"))
 


### PR DESCRIPTION
This adds geographic Bx / By, and Ex / Ey from the site waveforms. Previously, I was using the declination, but the electrodes aren't always aligned with the geomagnetic directions. This information is in the `SiteLayout` field and can be used directly here. Also, add in the rotations directly so end users don't have to do it every time themselves.